### PR TITLE
Per https://github.com/python-poetry/poetry/issues/3591

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,9 @@ RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.1.15 && 
     poetry config virtualenvs.create false
 COPY . /gamutrf
 WORKDIR /gamutrf
-RUN rm -rf /usr/lib/python3/dist-packages/pycparser* && poetry install --no-interaction --no-ansi
+# TODO: https://github.com/python-poetry/poetry/issues/3591
+# Install pandas via pip to get wheel. Disabling the new installer/configuring a wheel source does not work.
+RUN rm -rf /usr/lib/python3/dist-packages/pycparser* && \
+    poetry run pip install pandas==1.5.0 && \
+    poetry install --no-interaction --no-ansi
 CMD ["gamutrf-scan", "--help"]


### PR DESCRIPTION
Ugly workaround for poetry 1.1.15 not being able to find a wheel for pandas, and then failing to build pandas. Disabling the new installer does not work, and we already use the latest pip module.