### PR TITLE
Feature/gamutrf tar dirs

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -19,5 +19,6 @@ jobs:
         docker run -t iqtlabs/gamutrf:latest gamutrf-samples2raw --help
         docker run -t iqtlabs/gamutrf:latest gamutrf-freqxlator --help
         docker run -t iqtlabs/gamutrf:latest gamutrf-waterfall --help
+        docker run -t iqtlabs/gamutrf:latest gamutrf-compress_dirs --help
         sudo apt-get update && sudo apt-get install -qy python3-pip
         docker compose -f orchestrator.yml -f worker.yml -f monitoring.yml -f specgram.yml build

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+tests/gamutrf_test_dir/*.tar*
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
-tests/gamutrf_test_dir/*.tar*
+
 
 # Translations
 *.mo
@@ -132,6 +132,7 @@ dmypy.json
 *.csv
 *.mp4
 *.png
+tests/gamutrf_test_dir/*.tar*
 
 # Temporary files
 *.swo

--- a/gamutrf/__main__.py
+++ b/gamutrf/__main__.py
@@ -1,5 +1,6 @@
 """Main entrypoint for GamutRF"""
 from gamutrf.api import main as api_main
+from gamutrf.compress_dirs import main as compress_dirs_main
 from gamutrf.freqxlator import main as freqxlator_main
 from gamutrf.samples2raw import main as samples2raw_main
 from gamutrf.scan import main as scan_main
@@ -11,6 +12,11 @@ from gamutrf.waterfall import main as waterfall_main
 def api():
     """Entrypoint for API"""
     api_main()
+
+
+def compress_dirs():
+    """Entrypoint for compress_dirs"""
+    compress_dirs_main()
 
 
 def freqxlator():

--- a/gamutrf/compress_dirs.py
+++ b/gamutrf/compress_dirs.py
@@ -1,0 +1,100 @@
+import argparse
+import concurrent.futures
+import os
+import time
+import tarfile
+import gzip
+
+def check_tld(top_dir, args):
+    if not os.path.exists(top_dir):
+        print(f"Top-level directory '{top_dir}' does not exist.")
+        return []
+
+    if not os.path.isdir(top_dir):
+        print(f"'{top_dir}' is not a directory.")
+        return []
+
+    valid_folders = []
+    current_time = time.time()
+
+    print(f"Folders inside '{top_dir}' that are more than {args.threshold_seconds} seconds old:")
+
+    for dir in os.listdir(top_dir):
+        dir_path = os.path.join(top_dir, dir)
+        if os.path.isdir(dir_path):
+            folder_mtime = os.path.getmtime(dir_path)
+            if current_time - folder_mtime > args.threshold_seconds:
+                print(f"Folder: {dir}")
+                valid_folders.append(dir_path)
+
+    return valid_folders
+
+def tar_directories(dir_paths, args):
+
+    # Get a list of subdirectories within the top-level directory
+    #subdirectories = [subdir for subdir in os.listdir(top_dir)
+    #                  if os.path.isdir(os.path.join(top_dir, subdir))]
+
+    tar_filenames = []
+    
+    for dir_path in dir_paths:
+
+        # Create a tar file object
+        if args.compress:
+            tar_filename = f"{dir_path}.tar.gz"
+            tar_file = tarfile.open(tar_filename, "w:gz")
+        else:
+            tar_filename = f"{dir_path}.tar"
+            tar_file = tarfile.open(tar_filename, "w")
+            
+        
+        # Add all files in the directory to the tar file
+        for root, dirs, files in os.walk(dir_path):
+            for file in files:
+                file_path = os.path.join(root, file)
+                tar_file.add(file_path)
+        
+        # Close the tar file
+        tar_file.close()
+        
+        tar_filenames.append(tar_filename)
+        
+        # Delete if --delete
+        if args.delete:
+            for root, dirs, files in os.walk(dir_path):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    os.remove(file_path)
+            os.rmdir(dir_path)
+    
+    return tar_filenames
+
+def argument_parser():
+    parser = argparse.ArgumentParser(description="tar and compress recording directories")
+    parser.add_argument(
+        "dir", default="", type=str, help="Top level directory containing recordings"
+    )
+    parser.add_argument("--compress", dest="compress", action="store_true" help="compress (gzip) directories")
+    parser.add_argument("--delete", dest="delete", action="store_true", help="delete after compressing")
+    parser.add_argument("--threshold_seconds", dest="threshold_seconds", type=int, help="delete after compressing")
+    parser.set_defaults(dir="", dont_compress=False, delete=False, threshold_seconds=300)
+    return parser
+
+
+def main():
+    parser = argument_parser()
+    args = parser.parse_args()
+
+    # Check for valid subdirs
+    valid_folders = check_tld(args.dir, args)
+
+    # Process subdirs
+    if valid_folders:
+        tarred_filenames = tar_directories(valid_folders, args)
+        print("Tarred files:")
+        for filename in tarred_filenames:
+            print(filename)
+        print('...finished processing files')
+    else:
+        print("No valid folders found.")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ gamutrf-scan = 'gamutrf.__main__:scan'
 
 gamutrf-sigfinder = 'gamutrf.__main__:sigfinder'
 gamutrf-specgram = 'gamutrf.__main__:specgram'
+gamutrf-compress_dirs = 'gamutrf.__main__:compress_dirs'
 
 gamutrf-waterfall = 'gamutrf.__main__:waterfall'
 

--- a/tests/test_compress_dirs.py
+++ b/tests/test_compress_dirs.py
@@ -6,6 +6,7 @@ import unittest
 from gamutrf.compress_dirs import check_tld
 from gamutrf.compress_dirs import tar_directories
 from gamutrf.compress_dirs import argument_parser 
+from gamutrf.compress_dirs import export_to_path
 
 TESTDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data/gamutrf_test_dir")
 
@@ -16,18 +17,20 @@ class FakeArgs:
         delete,
         compress,
         threshold_seconds
+        export_path
     ):
         self.dir=dir
         self.delete=delete
         self.compress=compress
         self.threshold_seconds=threshold_seconds
+        self.threshold_path=threshold_seconds
 
 
 def test_argument_parser():
     argument_parser()
 
 def test_check_valid_tld():
-    args=FakeArgs(TESTDIR, False, True, 300)
+    args=FakeArgs(TESTDIR, False, True, 300, "")
     folders=check_tld(TESTDIR, args)
     assert("00001" in folders)
     assert("00002" in folders)
@@ -36,13 +39,13 @@ def test_check_valid_tld():
 
 def test_check_invalid_tld():
     INVALID_TESTDIR=TESTDIR+"_invalid"
-    args=FakeArgs(INVALID_TESTDIR, False, True, 300)
+    args=FakeArgs(INVALID_TESTDIR, False, True, 300, "")
     folders=check_tld(TESTDIR, args)
     assert(folders.__sizeof__ == 0)
 
 def test_tar_directories():
     #Test without compression
-    args=FakeArgs(TESTDIR, False, False, 300)
+    args=FakeArgs(TESTDIR, False, False, 300, "")
     folders=check_tld(TESTDIR, args)
     tarred_files = tar_directories(folders,args)
     assert("00001.tar" in tarred_files)
@@ -51,9 +54,12 @@ def test_tar_directories():
     assert(os.path.exists(os.join(TESTDIR, "00001.tar")))
     assert(os.path.exists(os.join(TESTDIR, "00002.tar")))
     assert(os.path.exists(os.join(TESTDIR, "00003.tar")))
+    os.remove(os.path.join(TESTDIR, "00001.tar"))
+    os.remove(os.path.join(TESTDIR, "00002.tar"))
+    os.remove(os.path.join(TESTDIR, "00003.tar"))
 
     #Test with compression
-    args=FakeArgs(TESTDIR, False, True, 300)
+    args=FakeArgs(TESTDIR, False, True, 300, "")
     folders=check_tld(TESTDIR, args)
     tarred_files = tar_directories(folders,args)
     assert("00001.tar.gz" in tarred_files)
@@ -62,6 +68,16 @@ def test_tar_directories():
     assert(os.path.exists(os.join(TESTDIR, "00001.tar.gz")))
     assert(os.path.exists(os.join(TESTDIR, "00002.tar.gz")))
     assert(os.path.exists(os.join(TESTDIR, "00003.tar.gz")))
+    os.remove(os.path.join(TESTDIR, "00001.tar.gz"))
+    os.remove(os.path.join(TESTDIR, "00002.tar.gz"))
+    os.remove(os.path.join(TESTDIR, "00003.tar.gz"))
+
+def test_threshold_seconds():
+    args=FakeArgs(TESTDIR, False, True, 300, "")
+    os.mkdir(os.path.join(TESTDIR,"new_folder"))
+    folders=check_tld(TESTDIR, args)
+    assert("new_folder" not in folders)
+    os.rmdir(os.path.join(TESTDIR,"new_folder"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_compress_dirs.py
+++ b/tests/test_compress_dirs.py
@@ -1,0 +1,67 @@
+import time
+import os
+import pytest
+import unittest
+
+from gamutrf.compress_dirs import check_tld
+from gamutrf.compress_dirs import tar_directories
+from gamutrf.compress_dirs import argument_parser 
+
+TESTDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data/gamutrf_test_dir")
+
+class FakeArgs:
+    def __init__(
+        self,
+        dir,
+        delete,
+        compress,
+        threshold_seconds
+    ):
+        self.dir=dir
+        self.delete=delete
+        self.compress=compress
+        self.threshold_seconds=threshold_seconds
+
+
+def test_argument_parser():
+    argument_parser()
+
+def test_check_valid_tld():
+    args=FakeArgs(TESTDIR, False, True, 300)
+    folders=check_tld(TESTDIR, args)
+    assert("00001" in folders)
+    assert("00002" in folders)
+    assert("00003" in folders)
+    assert("scan.csv" not in folders)
+
+def test_check_invalid_tld():
+    INVALID_TESTDIR=TESTDIR+"_invalid"
+    args=FakeArgs(INVALID_TESTDIR, False, True, 300)
+    folders=check_tld(TESTDIR, args)
+    assert(folders.__sizeof__ == 0)
+
+def test_tar_directories():
+    #Test without compression
+    args=FakeArgs(TESTDIR, False, False, 300)
+    folders=check_tld(TESTDIR, args)
+    tarred_files = tar_directories(folders,args)
+    assert("00001.tar" in tarred_files)
+    assert("00002.tar" in tarred_files)
+    assert("00003.tar" in tarred_files)
+    assert(os.path.exists(os.join(TESTDIR, "00001.tar")))
+    assert(os.path.exists(os.join(TESTDIR, "00002.tar")))
+    assert(os.path.exists(os.join(TESTDIR, "00003.tar")))
+
+    #Test with compression
+    args=FakeArgs(TESTDIR, False, True, 300)
+    folders=check_tld(TESTDIR, args)
+    tarred_files = tar_directories(folders,args)
+    assert("00001.tar.gz" in tarred_files)
+    assert("00002.tar.gz" in tarred_files)
+    assert("00003.tar.gz" in tarred_files)
+    assert(os.path.exists(os.join(TESTDIR, "00001.tar.gz")))
+    assert(os.path.exists(os.join(TESTDIR, "00002.tar.gz")))
+    assert(os.path.exists(os.join(TESTDIR, "00003.tar.gz")))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New utility to compress the output of gamutrf scanner. This is designed to be used after a scan has been completed, or called periodically to process the large volume of files created. When supplied a top level directory, compress_dirsA time threshold is used to avoid processing in use directories. All major contributions are in compress_dirs.py.

Tests are WIP.

Usage:
gamutrf-compress_dirs SCAN_DIR [--compress] [--export EXPORT_PATH] [--threshold_seconds 300] [--delete]

Example:
gamutrf-compress_dirs gamtrf-scan --compress --delete

Input Dir:
./gamutrf-scan
-0001
-0002
-0003

Expected Output
./gamutrf-scan
-0001.tar.gz
-0002.tar.gz
-0003.tar.gz