### PR TITLE
Basic unified SigMF support.

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,7 +6,7 @@ RUN git clone https://github.com/pothosware/SoapyUHD -b soapy-uhd-0.4.1
 RUN git clone https://github.com/Nuand/bladeRF.git -b 2023.02
 RUN git clone https://github.com/anarkiwi/lime-tools -b samples
 RUN git clone https://github.com/iqtlabs/uhd_sample_recorder -b v1.0.4
-RUN git clone https://github.com/iqtlabs/gr-iqtlabs -b 1.0.28
+RUN git clone https://github.com/iqtlabs/gr-iqtlabs -b 1.0.29
 RUN git clone https://github.com/google/flatbuffers -b v23.5.26
 RUN git clone https://github.com/nlohmann/json -b v3.11.2
 RUN git clone https://github.com/deepsig/libsigmf -b v1.0.2

--- a/gamutrf/grscan.py
+++ b/gamutrf/grscan.py
@@ -97,7 +97,7 @@ class grscan(gr.top_block):
                     iqtlabs.write_freq_samples(
                         "rx_freq",
                         gr.sizeof_gr_complex,
-                        "cf32",
+                        "cf32",  # TODO: write as int16.
                         fft_size,
                         sample_dir,
                         "samples",

--- a/gamutrf/sdr_recorder.py
+++ b/gamutrf/sdr_recorder.py
@@ -188,13 +188,15 @@ class SDRRecorder:
 
             if sigmf_:
                 meta = sigmf.SigMFFile(
+                    skip_checksum=True,  # expensive for large files
                     data_file=sample_file,
                     global_info={
-                        sigmf.SigMFFile.DATATYPE_KEY: SAMPLE_TYPE,
+                        sigmf.SigMFFile.DATATYPE_KEY: "c" + SAMPLE_TYPE,
                         sigmf.SigMFFile.SAMPLE_RATE_KEY: sample_rate,
                         sigmf.SigMFFile.VERSION_KEY: sigmf.__version__,
                     },
                 )
+                # TODO: add capture_details, source_file and gain when supported.
                 meta.add_capture(
                     0,
                     metadata={

--- a/tests/test_grscan.py
+++ b/tests/test_grscan.py
@@ -113,8 +113,8 @@ class GrscanTestCase(unittest.TestCase):
             del tb
             if not write_samples:
                 return
-            self.assertTrue([x for x in glob.glob(f"{tempdir}/*/*zst")] )
-            self.assertTrue([x for x in glob.glob(f"{tempdir}/*/*sigmf-meta")] )
+            self.assertTrue([x for x in glob.glob(f"{tempdir}/*/*zst")])
+            self.assertTrue([x for x in glob.glob(f"{tempdir}/*/*sigmf-meta")])
 
     def test_grscan_smoke(self):
         for wavelearner, write_samples in (


### PR DESCRIPTION
The scanner writes cf32s, while the worker writes cs16s (the scanner will change to cs16s in future), see https://github.com/sigmf/SigMF/blob/sigmf-v1.x/sigmf-spec.md#sigmf-dataset-format.

The python SigMF library doesn't include capture_details yet, so it omits source_file and gain.