### PR TITLE
File handling for gamutrf-offline

### DIFF
--- a/gamutrf/offline.py
+++ b/gamutrf/offline.py
@@ -144,6 +144,8 @@ def main():
     options = argument_parser().parse_args()
     filename = options.filename
     out_dir = os.path.dirname(filename)
+    if out_dir == "":
+        out_dir = "."
     _data_filename, _samples, meta = get_samples(filename)
     freq_start = int(meta["center_frequency"] - (meta["sample_rate"] / 2))
     scan_args = {

--- a/gamutrf/sample_reader.py
+++ b/gamutrf/sample_reader.py
@@ -155,6 +155,11 @@ def get_samples(filename):
 
     meta = sigmf.sigmffile.fromfile(filename)
     data_filename = filename[:meta_ext]
+    if os.path.splitext(data_filename)[-1] != ".sigmf-data":
+        data_filename = data_filename + ".sigmf-data"
+    if not os.path.exists(data_filename):
+        raise FileNotFoundError(data_filename)
+
     meta.set_data_file(data_filename)
     samples = meta.read_samples()
     global_meta = meta.get_global_info()


### PR DESCRIPTION
Bug: cannot process recordings in current directory. 
Defaults to "." if no out_dir found.

Bug:  data_filename does not contain file extension. Per sigmf format -  datafiles must end with .sigmf-data

https://github.com/sigmf/SigMF/blob/sigmf-v1.x/sigmf-spec.md#sigmf-file-types
Rules for SigMF Dataset files:
The Dataset file MUST have a .sigmf-data filename extension.