### PR TITLE
Fixes bugs with /reconfig api

### DIFF
--- a/gamutrf/grscan.py
+++ b/gamutrf/grscan.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from pathlib import Path
+import webcolors
 
 try:
     from gnuradio import filter as grfilter  # pytype: disable=import-error
@@ -240,6 +241,12 @@ class grscan(gr.top_block):
 
         if inference_output_dir:
             Path(inference_output_dir).mkdir(parents=True, exist_ok=True)
+
+        if inference_text_color:
+            wc = webcolors.name_to_rgb(inference_text_color, "css3")
+            inference_text_color = ",".join(
+                [str(c) for c in [wc.blue, wc.green, wc.red]]
+            )
 
         if inference_model_server and inference_model_name:
             x = 640

--- a/gamutrf/scan.py
+++ b/gamutrf/scan.py
@@ -2,7 +2,6 @@ import logging
 import signal
 import time
 import sys
-import webcolors
 from argparse import ArgumentParser, BooleanOptionalAction
 
 try:
@@ -480,12 +479,6 @@ def check_options(options):
 
     if options.scaling not in ["spectrum", "density"]:
         return "scaling must be 'spectrum' or 'density'"
-
-    if options.inference_text_color:
-        wc = webcolors.name_to_rgb(options.inference_text_color, "css3")
-        options.inference_text_color = ",".join(
-            [str(c) for c in [wc.blue, wc.green, wc.red]]
-        )
 
     iq_inference = options.iq_inference_model_server and options.iq_inference_model_name
     if iq_inference and not options.pretune:

--- a/orchestrator.yml
+++ b/orchestrator.yml
@@ -32,7 +32,7 @@ services:
     networks:
       - gamutrf
     ports:
-      - '9001:9000'
+      - '9001:9001'
       - '10000:10000'
       - '10001:10001'
     cap_add:


### PR DESCRIPTION
Fixes:
- 9001 port mapping issues in orchestrator.yml
- text_inference_color was being set to the RGB value, however when reconfig was called it was failing because it was no longer a text color string. Moved the RGB look up to the section where it is being used.